### PR TITLE
fix: CSV syntax on error

### DIFF
--- a/lib/services/grpc_api_client.dart
+++ b/lib/services/grpc_api_client.dart
@@ -40,7 +40,7 @@ class GRPCAPIClient implements APIClient {
           .then((value) => longURL + "," + value.shortUrl)
           .catchError((err) =>
               longURL +
-              "," +
+              ",," +
               ((err is GrpcError)
                   ? err.message ?? "Unknown error"
                   : err.toString())));

--- a/test/widget/grpc_api_client_test.dart
+++ b/test/widget/grpc_api_client_test.dart
@@ -42,7 +42,7 @@ void main() {
     expect(
         shortCSV,
         'https://google.com,https://webeng.ovh/r/cv6VxVdu\n'
-        'ftp://youtube.com,invalid long URL specified');
+        'ftp://youtube.com,,invalid long URL specified');
   });
 }
 


### PR DESCRIPTION
fixed CSV syntax on error:
Before : ftp://youtube.com,invalid long URL specified
Now: ftp://youtube.com,,invalid long URL specified